### PR TITLE
Fix for Spring Boot 2.0

### DIFF
--- a/acceptance-test/appengine-spring-boot-java/build.gradle
+++ b/acceptance-test/appengine-spring-boot-java/build.gradle
@@ -1,14 +1,30 @@
+buildscript {
+    repositories {
+        jcenter()
+        // TODO: remove when 2.0.0 is released
+        maven { url 'https://repo.spring.io/libs-milestone' }
+    }
+    dependencies {
+        classpath 'org.springframework.boot:spring-boot-gradle-plugin:2.0.0.M6'
+    }
+}
+
 plugins {
     id 'java'
-    id 'org.springframework.boot' version '1.5.6.RELEASE'
+    //id 'org.springframework.boot' version '2.0.0.RELEASE'
     id 'org.hidetake.appengine.spring.boot'
 }
+
+apply plugin: 'org.springframework.boot'
+apply plugin: 'io.spring.dependency-management'
 
 sourceCompatibility = JavaVersion.VERSION_1_8
 targetCompatibility = JavaVersion.VERSION_1_8
 
 repositories {
     jcenter()
+    // TODO: remove when 2.0.0 is released
+    maven { url 'https://repo.spring.io/libs-milestone' }
 }
 
 dependencies {

--- a/acceptance-test/appengine-spring-boot-java/src/main/java/example/App.java
+++ b/acceptance-test/appengine-spring-boot-java/src/main/java/example/App.java
@@ -1,8 +1,12 @@
 package example;
 
+import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.web.support.SpringBootServletInitializer;
+import org.springframework.boot.web.servlet.support.SpringBootServletInitializer;
 
 @SpringBootApplication
 public class App extends SpringBootServletInitializer {
+    public static void main(String[] args) {
+        SpringApplication.run(App.class, args);
+    }
 }

--- a/src/main/groovy/org/hidetake/gradle/appengine/spring/boot/AppEngineSpringBootPlugin.groovy
+++ b/src/main/groovy/org/hidetake/gradle/appengine/spring/boot/AppEngineSpringBootPlugin.groovy
@@ -49,7 +49,8 @@ class AppEngineSpringBootPlugin implements Plugin<Project> {
    * Configure the Spring Boot plugin.
    */
   static void configureSpringBootPlugin(Project project) {
-    project.tasks.bootRepackage.enabled = false
-    project.tasks.findMainClass.enabled = false
+    // Spring Boot 1.x only
+    project.tasks.findByPath('bootRepackage')?.enabled = false
+    project.tasks.findByPath('findMainClass')?.enabled = false
   }
 }


### PR DESCRIPTION
This allows the plugin works for Spring Boot 1.x and 2.x.

Note that 2.0 plugin does not have `bootRepackage` task and `findMainClass` task. Also 2.0 requires a main method regardless of war.